### PR TITLE
refactor: scope "favorites-list", use module, use native `quarto.json.encode()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ yarn-error.log
 *~
 **/*.quarto_ipynb
 .claude
+
+/.luarc.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ashley Henry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The extension automatically adds a collapsible "My Favorites" section to the sid
 In the `_quarto.yml` add:
 
 ```yaml
+website:
+  navbar:
     right:
       - text: "Favs"
         href: favorites.qmd

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ Users can click on this button to add or remove the current page from their favo
 
 To create a dedicated page that displays all favorited pages, create a new Quarto document (e.g., `favorites.qmd`) with the following YAML front matter:
 
-```yaml
+```markdown
 ---
 title: "My Favorites"
-favorites_list: true
+extensions:
+  favorites:
+    favorites-list: true
 ---
 
 This page displays all your favorited pages from this website.
@@ -68,16 +70,19 @@ The favorites page includes Export and Import buttons that allow users to:
 2. **Import Favorites**: Load favorites from a previously exported JSON file
 
 These features allow users to:
+
 - Back up their favorites for safekeeping
 - Transfer favorites between different browsers or devices
 - Share their favorites with other users
 - Organize favorites in a custom order
 
 When importing, users have the option to either:
+
 - Merge the imported favorites with their existing ones (avoiding duplicates)
 - Replace all existing favorites with the imported ones
 
 The extension validates imported favorites to check if they belong to the current website:
+
 - External links (from different websites) are highlighted with warning icons
 - Users receive notifications about the number of external links in their imports
 - Users can choose whether to include external links in their favorites list

--- a/README.md
+++ b/README.md
@@ -130,4 +130,5 @@ Section dividers are visual elements that help organize the favorites list witho
 
 ## License
 
-MIT License
+This project is licensed under the MIT License.
+See the [LICENSE](LICENSE) file for details.

--- a/_extensions/favorites/LICENSE
+++ b/_extensions/favorites/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ashley Henry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_extensions/favorites/_modules/utils.lua
+++ b/_extensions/favorites/_modules/utils.lua
@@ -3,26 +3,6 @@
 
 local utils = {}
 
---- Simple function to create JSON string manually (no dependency on pandoc.utils.to_json)
---- @param val any The value to encode
---- @return string The JSON-encoded string
-function utils.json_encode(val)
-  if type(val) == "string" then
-    return '"' .. val:gsub('"', '\\"'):gsub("\n", "\\n") .. '"'
-  elseif type(val) == "table" then
-    local json = "{"
-    local first = true
-    for k, v in pairs(val) do
-      if not first then json = json .. "," end
-      first = false
-      json = json .. '"' .. k .. '":' .. utils.json_encode(v)
-    end
-    return json .. "}"
-  else
-    return tostring(val)
-  end
-end
-
 --- Read a file from the filesystem
 --- @param path string The file path
 --- @return string|nil The file contents or nil if not found

--- a/_extensions/favorites/_modules/utils.lua
+++ b/_extensions/favorites/_modules/utils.lua
@@ -1,0 +1,111 @@
+-- utils.lua
+-- Shared utility functions for the favorites extension
+
+local utils = {}
+
+--- Simple function to create JSON string manually (no dependency on pandoc.utils.to_json)
+--- @param val any The value to encode
+--- @return string The JSON-encoded string
+function utils.json_encode(val)
+  if type(val) == "string" then
+    return '"' .. val:gsub('"', '\\"'):gsub("\n", "\\n") .. '"'
+  elseif type(val) == "table" then
+    local json = "{"
+    local first = true
+    for k, v in pairs(val) do
+      if not first then json = json .. "," end
+      first = false
+      json = json .. '"' .. k .. '":' .. utils.json_encode(v)
+    end
+    return json .. "}"
+  else
+    return tostring(val)
+  end
+end
+
+--- Read a file from the filesystem
+--- @param path string The file path
+--- @return string|nil The file contents or nil if not found
+function utils.read_file(path)
+  local file = io.open(path, "r")
+  if file then
+    local content = file:read("*all")
+    file:close()
+    return content
+  end
+  return nil
+end
+
+--- Get a metadata value from the extension's namespace
+--- Supports both extensions.favorites.key and direct key access for backwards compatibility
+--- @param meta table The document metadata
+--- @param key string The configuration key to retrieve
+--- @return any|nil The value if found, nil otherwise
+function utils.get_metadata_value(meta, key)
+  -- Check if meta exists
+  if not meta then
+    return nil
+  end
+
+  -- First check for extensions.favorites.key pattern (preferred)
+  if meta.extensions and meta.extensions.favorites then
+    local ext_meta = meta.extensions.favorites
+    if ext_meta[key] then
+      return ext_meta[key]
+    end
+  end
+
+  -- Fallback to direct key access for backwards compatibility
+  if meta[key] then
+    return meta[key]
+  end
+
+  return nil
+end
+
+--- Check if this is a favorites list page
+--- @param meta table The document metadata
+--- @return boolean True if this is a favorites list page
+function utils.is_favorites_list(meta)
+  -- Support both extensions.favorites.favorites-list and direct favorites_list for backwards compatibility
+  if meta.extensions and meta.extensions.favorites and meta.extensions.favorites["favorites-list"] then
+    return true
+  elseif meta.favorites_list then
+    return true
+  end
+  return false
+end
+
+--- Extract the page title from metadata
+--- @param meta table The document metadata
+--- @return string The page title or "Untitled Page" as fallback
+function utils.get_page_title(meta)
+  if meta.title then
+    return pandoc.utils.stringify(meta.title)
+  end
+  return "Untitled Page"
+end
+
+--- Get the path to the favorites page, accounting for project offset
+--- @return string The path to favorites.html
+function utils.get_favorites_page_path()
+  local favorites_page_path = "favorites.html"
+  if quarto and quarto.project and quarto.project.offset then
+    local offset = quarto.project.offset
+
+    -- Remove any leading dot to avoid URL issues
+    if offset:sub(1, 1) == "." then
+      offset = offset:sub(2)
+    end
+
+    -- Ensure there's a forward slash between the offset and filename
+    if offset ~= "" and offset:sub(-1) ~= "/" then
+      offset = offset .. "/"
+    end
+
+    favorites_page_path = offset .. "favorites.html"
+  end
+  return favorites_page_path
+end
+
+return utils

--- a/_extensions/favorites/favorites-button.lua
+++ b/_extensions/favorites/favorites-button.lua
@@ -1,23 +1,8 @@
 -- favorites-button.lua
 -- This filter adds a favorites button to each page
 
--- Simple function to create JSON string manually (no dependency on pandoc.utils.to_json)
-function json_encode(val)
-  if type(val) == "string" then
-    return '"' .. val:gsub('"', '\\"'):gsub("\n", "\\n") .. '"'
-  elseif type(val) == "table" then
-    local json = "{"
-    local first = true
-    for k, v in pairs(val) do
-      if not first then json = json .. "," end
-      first = false
-      json = json .. '"' .. k .. '":' .. json_encode(v)
-    end
-    return json .. "}"
-  else
-    return tostring(val)
-  end
-end
+--- Load utils module
+local utils = require(quarto.utils.resolve_path('_modules/utils.lua'):gsub('%.lua$', ''))
 
 -- Function to handle metadata and format title
 function Meta(meta)
@@ -37,13 +22,10 @@ function Meta(meta)
     })
 
     -- Extract title from metadata
-    local title = "Untitled Page"
-    if meta.title then
-      title = pandoc.utils.stringify(meta.title)
-    end
+    local title = utils.get_page_title(meta)
 
     -- Create page info as JSON
-    local page_info = json_encode({title = title})
+    local page_info = utils.json_encode({title = title})
 
     -- Create the favorites button HTML
     local button_html = string.format([[

--- a/_extensions/favorites/favorites-button.lua
+++ b/_extensions/favorites/favorites-button.lua
@@ -25,7 +25,7 @@ function Meta(meta)
     local title = utils.get_page_title(meta)
 
     -- Create page info as JSON
-    local page_info = utils.json_encode({title = title})
+    local page_info = quarto.json.encode({title = title})
 
     -- Create the favorites button HTML
     local button_html = string.format([[

--- a/_extensions/favorites/favorites-list.lua
+++ b/_extensions/favorites/favorites-list.lua
@@ -1,6 +1,9 @@
 -- favorites-list.lua
 -- This filter creates the favorites list functionality
 
+--- Load utils module
+local utils = require(quarto.utils.resolve_path('_modules/utils.lua'):gsub('%.lua$', ''))
+
 -- Function to handle metadata and check for favorites list page
 function Meta(meta)
   -- Only process if we're in HTML format
@@ -17,7 +20,7 @@ function Meta(meta)
     ]]
 
     -- Check if this is the favorites list page
-    if meta.favorites_list then
+    if utils.is_favorites_list(meta) then
       -- Insert the favorites list HTML into the document
       quarto.doc.include_text("before-body", html)
     end

--- a/_extensions/favorites/favorites.lua
+++ b/_extensions/favorites/favorites.lua
@@ -31,7 +31,7 @@ function Pandoc(doc)
     local is_favorites_list = utils.is_favorites_list(doc.meta)
 
     -- Create page info as JSON
-    local page_info = utils.json_encode({title = title})
+    local page_info = quarto.json.encode({title = title})
 
     -- Create button HTML
     local button_html = string.format([[

--- a/_extensions/favorites/favorites.lua
+++ b/_extensions/favorites/favorites.lua
@@ -75,6 +75,15 @@ function Pandoc(doc)
     -- For debugging
     -- print("Favorites page path: " .. favorites_page_path)
 
+    -- Check if this is a favorites list page
+    -- Support both extensions.favorites.favorites-list and direct favorites_list for backwards compatibility
+    local is_favorites_list = false
+    if doc.meta.extensions and doc.meta.extensions.favorites and doc.meta.extensions.favorites["favorites-list"] then
+      is_favorites_list = true
+    elseif doc.meta.favorites_list then
+      is_favorites_list = true
+    end
+
     -- Create page info as JSON
     local page_info = json_encode({title = title})
 
@@ -93,7 +102,7 @@ function Pandoc(doc)
     quarto.doc.include_text("before-body", button_html)
 
     -- Add sidebar favorites (if not on the favorites page itself)
-    if not doc.meta.favorites_list then
+    if not is_favorites_list then
       -- Read in the sidebar HTML template
       local sidebar_template_path = quarto.utils.resolve_path("favorites-sidebar.html")
       local sidebar_html = read_file(sidebar_template_path) or ""
@@ -200,7 +209,7 @@ function Pandoc(doc)
     end
 
     -- If this is a favorites list page, add the favorites list HTML with export/import functionality
-    if doc.meta.favorites_list then
+    if is_favorites_list then
       local list_html = [[
         <div class="favorites-list-container">
           <div class="favorites-header">

--- a/favorites.qmd
+++ b/favorites.qmd
@@ -1,6 +1,8 @@
 ---
 page_title: false
-favorites_list: true
+extensions:
+  favorites:
+    favorites-list: true
 ---
 
 This page displays all your favorited pages from this website.


### PR DESCRIPTION
- Scope the "favorites-list" extension option to prevent conflicts with Quarto CLI. (https://github.com/quarto-dev/quarto-cli/issues/12894)
- Rename "favorites_list" into "favorites-list" for consistency with YAML code style in Quarto.
- Use native `quarto.json.encode()` (https://quarto.org/docs/extensions/lua-api.html#json-encoding)
- Add license file.